### PR TITLE
chore(@aws-cdk/aws-lambda-event-sources): Fix typo in example for kinesis streams

### DIFF
--- a/packages/@aws-cdk/aws-lambda-event-sources/README.md
+++ b/packages/@aws-cdk/aws-lambda-event-sources/README.md
@@ -192,7 +192,7 @@ import { KinesisEventSource } from '@aws-cdk/aws-lambda-event-sources';
 
 const stream = new kinesis.Stream(this, 'MyStream');
 
-myFunction.addEventSource(new KinesisEventSource(queue, {
+myFunction.addEventSource(new KinesisEventSource(stream, {
   batchSize: 100, // default
   startingPosition: lambda.StartingPosition.TRIM_HORIZON
 });


### PR DESCRIPTION
This is a simple typo pointing to a variable that was not declared in the example for Kinesis.


The motivation for this change is:

- To ensure developers have accurate documentation.
- To ensure developers have a good experience when attempting to understand the features of the CDK from the documentation.

There is a convention in the README's to refer to variables outside the scope of the example e.g.

```ts
myFunction.addEventSource( //etc
```

Where `myFunction` is not declared in the scope of the example. This fix prevents the assumption that a `queue` resource has also been created outside the scope of the example.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
